### PR TITLE
allows custom axios headers

### DIFF
--- a/src/createBackendConnector.js
+++ b/src/createBackendConnector.js
@@ -20,12 +20,12 @@ export default function createBackendConnector(axiosConfig = {}) {
             throw new Error(`The request httpMethod must be a string. Found ${typeof req.httpMethod}`)
         }
 
-        return axios(Object.assign(axiosConfig, {
+        return axios(Object.assign({
             url: req.url,
             method: req.httpMethod,
             headers: req.headers,
             data: req.data,
-        }))
+        }, axiosConfig))
         .catch((error) => {
             throw error.response
         })

--- a/src/createBackendConnector.js
+++ b/src/createBackendConnector.js
@@ -20,12 +20,17 @@ export default function createBackendConnector(axiosConfig = {}) {
             throw new Error(`The request httpMethod must be a string. Found ${typeof req.httpMethod}`)
         }
 
-        return axios(Object.assign({
+        let requestHeaders = req.headers
+        if (axiosConfig.headers) {
+            requestHeaders = Object.assign({}, req.headers, axiosConfig.headers)
+        }
+
+        return axios(Object.assign(axiosConfig, {
             url: req.url,
             method: req.httpMethod,
-            headers: req.headers,
+            headers: requestHeaders,
             data: req.data,
-        }, axiosConfig))
+        }))
         .catch((error) => {
             throw error.response
         })

--- a/src/createBackendConnector.js
+++ b/src/createBackendConnector.js
@@ -22,7 +22,7 @@ export default function createBackendConnector(axiosConfig = {}) {
 
         let requestHeaders = req.headers
         if (axiosConfig.headers) {
-            requestHeaders = Object.assign({}, req.headers, axiosConfig.headers)
+            requestHeaders = Object.assign({}, axiosConfig.headers, req.headers)
         }
 
         return axios(Object.assign(axiosConfig, {

--- a/tests/createBackendConnector.test.js
+++ b/tests/createBackendConnector.test.js
@@ -78,6 +78,18 @@ describe('Backend Connector', () => {
         });
     });
 
+    it('axios headers overwrite', () => {
+        const connector = createBackendConnector({
+            headers: { Accept: 'application/json' }
+        })
+
+        return connector.read({ url: '/api/list/', httpMethod: 'get', headers: { userToken: 'x62bkdds62' } })
+        .then((response) => {
+            expect(response.request.requestHeaders.userToken).toBe('x62bkdds62');
+            expect(response.request.requestHeaders.Accept).toBe('application/json');
+        });
+    })
+
     it('handles baseURL', () => {
         const connector = createBackendConnector({
             baseURL: '/api/',


### PR DESCRIPTION
I was using a Django Rest Framework API with `crudl-connectors-drf` and it turns out that in Firefox 48 I always got HTML returned, instead of the excepted JSON. That is due to this version of FFX sending `Accept: text/html` (Chrome for example sends `Accept: */*` by default).

So I had to explicitly overwrite the `Accept` header:

```js
import { createDRFConnector, defaults } from '@crudlio/crudl-connectors-drf'
defaults.axios.headers = { Accept: 'application/json' }
```

However, the order the options are merged together here worked the other way around: the original request headers would overwrite my custom header.

This PR fixes that :)